### PR TITLE
+app: in addition to +application:

### DIFF
--- a/src/JSTalk.h
+++ b/src/JSTalk.h
@@ -32,5 +32,6 @@
 + (void)resetPlugins;
 + (void)setShouldLoadJSTPlugins:(BOOL)b;
 + (id)application:(NSString*)app;
++ (id)app:(NSString*)app;
 
 @end

--- a/src/JSTalk.m
+++ b/src/JSTalk.m
@@ -338,6 +338,9 @@ static NSMutableArray *JSTalkPluginList;
     return [self applicationOnPort:[NSString stringWithFormat:@"%@.JSTalk", bundleId]];
 }
 
++ (id)app:(NSString*)app {
+    return [self application:app];
+}
 
 + (id)proxyForApp:(NSString*)app {
     return [self application:app];


### PR DESCRIPTION
Add +app: to shorten up app communication.
example [[JSTalk app:'Hibari'] selectedTweet](versus [[JSTalk application:'Hibari'] selectedTweet])

(I'm used to `app` expanding to `application` in AppleScript)
