### PR TITLE
Added displayDialog withTitle withOK withNOK to provide both "OK" and "Cancel" buttons in modal dialog

### DIFF
--- a/src/JSTExtras.m
+++ b/src/JSTExtras.m
@@ -132,6 +132,17 @@
     SetFrontProcess( &xpsn );
 }
 
+
+- (NSInteger) displayDialog:(NSString*)msg withTitle:(NSString*)title withOK:(NSString*)oktxt withNOK:(NSString*)noktxt {
+    
+    NSAlert *alert = [NSAlert alertWithMessageText:title defaultButton:oktxt alternateButton:noktxt otherButton:nil informativeTextWithFormat:@"%@", msg];
+    
+    NSInteger button = [alert runModal];
+    
+    return button;
+}
+
+
 - (NSInteger)displayDialog:(NSString*)msg withTitle:(NSString*) title {
     
     NSAlert *alert = [NSAlert alertWithMessageText:title defaultButton:nil alternateButton:nil otherButton:nil informativeTextWithFormat:@"%@", msg];


### PR DESCRIPTION
New displayDialog function - same as old, only allows filling
defaultButton and alternateButton txt fields.

This should work back in the main branch too - seems ok under 10.7 and earlier.
